### PR TITLE
Add debug logging

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -6,6 +6,7 @@ module.exports = WorkerClient;
 var uuid = require('uuid');
 var amqplib = require('amqplib');
 var when = require('when');
+var debug = require('debug')('qc:client');
 
 WorkerClient.CLOSED = 0;
 WorkerClient.CONNECTING = 1;
@@ -31,13 +32,16 @@ WorkerClient.prototype.connect = function () {
     return amqplib
         .connect('amqp://localhost')
         .then(function(connection) {
+            debug('Connected');
             workerClient.connection = connection;
             return workerClient.connection.createChannel();
         })
         .then(function(channel) {
+            debug('Channel created');
             return workerClient.registerChannel(channel);
         })
         .then(function() {
+            debug('Channel registered');
             workerClient.readyState = WorkerClient.READY;
             return when.all(workerClient._awaitingConnectionPool.map(function(f) {
                 return f();
@@ -49,17 +53,23 @@ WorkerClient.prototype.connect = function () {
 WorkerClient.prototype.registerChannel = function(channel) {
     var workerClient = this;
     if (workerClient.channel) {
+        debug('(err) Undisposed channel detected');
         throw new Error('Undisposed channel detected');
     }
+
     workerClient.channel = channel;
+
     channel.on('error', function(err) {
+        debug('(err) Channel got error', err);
         console.log('got error', err);
         workerClient.compound.sendError(err);
     });
     channel.on('close', function() {
+        debug('Channel close');
         delete workerClient.channel;
         workerClient.readyState = WorkerClient.CLOSED;
     });
+
     var assertedOutputs = {};
     var flow = when.Promise.resolve();
     Object.keys(workerClient._channels).map(function(n) {
@@ -76,6 +86,7 @@ WorkerClient.prototype.registerChannel = function(channel) {
 
     function assertQueueWithHandler(name, ch) {
         var queueName = workerClient.commander.getRealQueueName(name);
+
         return workerClient.channel
             .assertQueue(queueName, {
                 exclusive: name ? false : true,
@@ -90,6 +101,8 @@ WorkerClient.prototype.registerChannel = function(channel) {
             });
 
         function handleResult(msg) {
+            debug('Consume message from queue', queueName);
+
             var fullCorrelationId = msg.properties.correlationId.split('#');
             var handler = workerClient._channels[fullCorrelationId[0]];
             var fn = workerClient._awaitingResponseHandlers[fullCorrelationId[1]];
@@ -107,22 +120,28 @@ WorkerClient.prototype.registerChannel = function(channel) {
 
 WorkerClient.prototype._send = function (message, priority) {
     var workerClient = this;
+
     return new when.Promise(function(resolve, reject) {
         var corrId = uuid.v4();
         var fullCorrelationId = message.name + '#' + corrId;
         var handlerQueue = workerClient._channels[message.name];
+
         if (!handlerQueue) {
             console.log('no remote call', message.name, Object.keys(workerClient._channels));
             return reject(new Error('Remote call not registered'));
         }
+
         if ('undefined' === typeof handlerQueue.channelDescriptor.outputQueueId) {
-            return reject(new Error('Output channel for "' + handlerQueue.channelDescriptor.name + '" is not defined'));
+            var errorMessage = 'Output channel for "' + handlerQueue.channelDescriptor.name + '" is not defined';
+            debug('(err) ' + errorMessage);
+            return reject(new Error(errorMessage));
         }
+
         var queue = workerClient.commander.getRealQueueName(handlerQueue.channelDescriptor.input);
 
         message = JSON.stringify(message);
 
-        console.log(' [wc] send to queue (%s:%s), will reply to %s', queue, handlerQueue.channelDescriptor.name, handlerQueue.channelDescriptor.outputQueueId);
+        debug('Send to queue (%s:%s), will reply to %s', queue, handlerQueue.channelDescriptor.name, handlerQueue.channelDescriptor.outputQueueId);
 
         workerClient.channel.sendToQueue(queue, new Buffer(message), {
             correlationId: fullCorrelationId,
@@ -131,17 +150,29 @@ WorkerClient.prototype._send = function (message, priority) {
         });
 
         if (!handlerQueue.channelDescriptor.output) {
+            debug('Add awaiting response handler', corrId);
+
             workerClient._awaitingResponseHandlers[corrId] = function(err, res) {
                 delete workerClient._awaitingResponseHandlers[corrId];
-                corrId = null;
+
                 if (err) {
                     if (res) {
                         err.response = res;
                     }
+
+                    debug('Reject awaiting response', corrId, err);
+
+                    corrId = null;
                     return reject(err);
                 }
+
+                debug('Resolve awaiting response', corrId);
+
+                corrId = null;
                 resolve(res);
             };
+
+            debug('Totlal awaiting response handlers', Object.keys(workerClient._awaitingResponseHandlers).length);
         } else {
             resolve({scheduled: corrId});
         }
@@ -149,7 +180,10 @@ WorkerClient.prototype._send = function (message, priority) {
 };
 
 WorkerClient.prototype.callRemote = function(name, priority, args) {
+    debug('callRemote', name, args);
+
     var client = this;
+
     if (client.readyState === WorkerClient.READY) {
         return send();
     } else {

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,6 +4,7 @@
 module.exports = WorkerServer;
 
 var amqplib = require('amqplib');
+var debug = require('debug')('qc:server');
 
 var HANDLER_NOT_REGISTERED_ERR = 'Handler not registered';
 
@@ -19,28 +20,35 @@ WorkerServer.prototype.connect = function () {
         amqplib
         .connect('amqp://localhost')
         .then(function(connection) {
+            debug('Connected');
             workerServer.connection = connection;
             return workerServer.connection.createChannel();
         })
         .then(function(channel) {
+            debug('Channel created');
             if (workerServer.channel) {
                 throw new Error('Undisposed channel detected');
             }
             workerServer.channel = channel;
             channel.on('error', function(err) {
                 // emit error
+                debug('Channel error', err);
                 console.log(err);
             });
             channel.on('close', function onclosed() {
                 delete workerServer.channel;
                 delete workerServer.connectPromise;
-                console.log(' [ws] channel closed');
-                console.log(' [ws] reconnecting in 1 sec');
+
+                debug('Channel closed');
+                debug('Reconnecting in 1 sec');
+
                 setTimeout(function() {
                     workerServer.connect().then(null, onclosed);
                 }, 1000);
             });
+
             channel.prefetch(1);
+
             workerServer.commander.descriptors.forEach(function(d) {
                 var q = workerServer.commander.getQueueByName(d.input);
                 channel.assertQueue(q.getName(), q.settings);
@@ -50,7 +58,7 @@ WorkerServer.prototype.connect = function () {
             });
         })
         .then(function() {
-            console.log(' [ws] Awaiting RPC requests');
+            debug('Awaiting RPC requests');
             return workerServer.channel;
         });
 
@@ -67,7 +75,7 @@ WorkerServer.prototype.handle = function (message) {
     var handler = this.handlers[content.name];
 
     if (!handler || 'function' !== typeof handler.handler) {
-        console.log(' [ws] No handlers for', content.name, 'known handlers:', Object.keys(this.handlers));
+        debug('(err) No handlers for', content.name, 'known handlers:', Object.keys(this.handlers));
         handler = {handler: function(args, fn) {
             fn(new Error(HANDLER_NOT_REGISTERED_ERR));
         }};
@@ -78,6 +86,7 @@ WorkerServer.prototype.handle = function (message) {
     handler.handler(content.args, function responseCallback(err, result) {
         if (err && err.message === HANDLER_NOT_REGISTERED_ERR) {
             didACK = true;
+            debug('(err) NACK: unknown handler');
             console.log(' [ws] nack: unknown handler');
             workerServer.channel.nack(message);
             return;
@@ -88,11 +97,12 @@ WorkerServer.prototype.handle = function (message) {
         var corrId = message.properties.correlationId;
 
         if (!didACK) {
-            console.log(' [ws] ACK');
+            debug('ACK (handler cb)', content.name);
             workerServer.channel.ack(message);
         }
 
-        console.log(' [ws] replying to ' + replyTo);
+        debug('Reply to ' + replyTo);
+
         workerServer.channel.sendToQueue(
             replyTo,
             new Buffer(responseJSON),
@@ -102,16 +112,18 @@ WorkerServer.prototype.handle = function (message) {
     }, function(ack) {
         didACK = true;
         if (ack) {
-            console.log(' [ws] ACK');
+            debug('ACK (handler ack cb)', content.name);
             workerServer.channel.ack(message);
         } else {
-            console.log(' [ws] NACK');
+            debug('NACK (handler ack cb)', content.name);
             workerServer.channel.nack(message);
         }
     });
 };
 
 WorkerServer.prototype.addHandler = function (channelDescriptor, handler) {
+    debug('addHandler', channelDescriptor.name);
+
     this.handlers[channelDescriptor.name] = {
         channelDescriptor: channelDescriptor,
         handler: handler

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "index.js",
   "dependencies": {
     "amqplib": "=0.3.2",
-    "when": "3.7.3",
+    "debug": "^2.2.0",
+    "request": "^2.58.0",
     "uuid": "2.0.1",
-    "request": "^2.58.0"
+    "when": "3.7.3"
   },
   "devDependencies": {
     "jshint": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "queue-commander",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Convenient interface for amqp lib",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
``` sh
    $ DEBUG='qc:*' node .
```

to get logs with timestamps:

``` sh
    $ DEBUG_COLORS=0 DEBUG='qc:*' node .
    # or write it to not a TTY
    $ DEBUG='qc:*' node . > out.log
```
